### PR TITLE
Add cronjob example for K8s academy

### DIFF
--- a/HANDSON.md
+++ b/HANDSON.md
@@ -105,6 +105,91 @@ kubectl delete pod nginx-pod
 .
 .
 
+# CronJob
+
+* Encrypt MySQL password, for example: echo -n 'password' | base64
+
+* Copy the output from the command above and save it into mysql-secret.yaml
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  password: <passencrypted-output>
+```
+
+* Use this command to generate the secret:
+``` 
+kubectl apply -f mysql-secret.yaml 
+```
+
+* Create a service account with storage-admin permission and generate key (to get the JSON file). Rename the file to service-account.json and store it where your Dockerfile is going to be placed
+
+* Create a Dockerfile with this content:
+```
+FROM google/cloud-sdk
+
+COPY service-account.json service-account.json
+
+RUN apt-get update && apt-get install -y mysql-client && rm -rf /var/lib/apt
+```
+
+* Build image:
+``` 
+docker build . -t gcr.io/<project_name>/<preffered-image-name>
+```
+
+* Push image:
+```
+docker push gcr.io/<project_name>/<preffered-image-name>
+```
+
+* Create the cronjob yaml (mysql-cronjob.yaml)
+```yaml
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: mysql-backup
+spec:
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: mysql-backup
+              image: gcr.io/<project_name>/<prefered-image-name>
+              env:
+                - name: GOOGLE_PROJECT
+                  value: <google-project>
+                - name: DB_HOST
+                  value: wordpress-mysql
+                - name: DB_USER
+                  value: root
+                - name: DB_NAME
+                  value: mysql
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysecret
+                      key: password
+                - name: GCS_BUCKET
+                  value: <my-bucket>
+                - name: GCS_SA
+                  value: service-account.json
+              args:
+                - /bin/bash
+                - -c
+                - mysqldump --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "$@" "${DB_NAME}" > "${DB_NAME}-$(date '+%d|%m|%Y-%H:%M:%S')".sql; gcloud config set project ${GOOGLE_PROJECT}; gcloud auth activate-service-account --key-file "${GCS_SA}"; gsutil cp *.sql gs://"${GCS_BUCKET}"
+``` 
+
+NOTE: This cronjob is activated every 10 mins. Check out the templates in [jobs folder](jobs)
+
+
 # Clean up
 
 Type `exit` on your *Cloud Shell* session.

--- a/jobs/Dockerfile
+++ b/jobs/Dockerfile
@@ -1,0 +1,5 @@
+FROM google/cloud-sdk
+
+COPY service-account.json service-account.json
+
+RUN apt-get update && apt-get install -y mysql-client && rm -rf /var/lib/apt

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -28,6 +28,8 @@ docker push gcr.io/<project_name>/<preffered-image-name>
 kubectl apply -f mysql-cronjob.yaml
 ```
 
+NOTE: This cronjob is activated every 10 mins
+
 ### References:
 
 https://medium.com/searce/cronjob-to-backup-mysql-on-gke-23bb706d9bbf

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -2,7 +2,7 @@
 
 * Connect to the cluster
 
-* Encrypt the user, for example: echo -n 'root' | base64
+* Encrypt the password, for example: echo -n 'password' | base64
 
 * Copy output from the command above and save it into mysql-secret.yaml
 

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,34 @@
+#Steps to create CronJob in Kubernetes
+
+* Connect to the cluster
+
+* Encrypt the user, for example: echo -n 'root' | base64
+
+* Copy output from the command above and save it into mysql-secret.yaml
+
+* Use this command to generate the secret:
+``` 
+kubectl apply -f mysql-secret.yaml 
+```
+
+* Create a service account with storage-admin permission and generate key (to get JSON file). Rename file to service-account.json
+
+* Build image:
+``` 
+docker build . -t gcr.io/<project_name>/<preffered-image-name>
+```
+
+* Push image:
+```
+docker push gcr.io/<project_name>/<preffered-image-name>
+```
+
+* Create cronjob in K8s
+```
+kubectl apply -f mysql-cronjob.yaml
+```
+
+### References:
+
+https://medium.com/searce/cronjob-to-backup-mysql-on-gke-23bb706d9bbf
+https://www.serverlab.ca/tutorials/containers/kubernetes/using-kubernetes-cronjob-to-backup-mysql-on-gke/

--- a/jobs/mysql-cronjob.yaml
+++ b/jobs/mysql-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: mysql-backup
 spec:
-  schedule: "*/1 * * * *"
+  schedule: "*/10 * * * *"
   jobTemplate:
     spec:
       template:
@@ -11,7 +11,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: mysql-backup
-              image: gcr.io/<project_name>/<preffered-image-name>
+              image: gcr.io/<project_name>/<prefered-image-name>
               env:
                 - name: GOOGLE_PROJECT
                   value: <google-project>
@@ -27,7 +27,7 @@ spec:
                       name: mysecret
                       key: password
                 - name: GCS_BUCKET
-                  value: myfirstbucketsgcg
+                  value: <my-bucket>
                 - name: GCS_SA
                   value: service-account.json
               args:

--- a/jobs/mysql-cronjob.yaml
+++ b/jobs/mysql-cronjob.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: mysql-backup
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: mysql-backup
+              image: gcr.io/<project_name>/<preffered-image-name>
+              env:
+                - name: GOOGLE_PROJECT
+                  value: <google-project>
+                - name: DB_HOST
+                  value: wordpress-mysql
+                - name: DB_USER
+                  value: root
+                - name: DB_NAME
+                  value: mysql
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysecret
+                      key: password
+                - name: GCS_BUCKET
+                  value: myfirstbucketsgcg
+                - name: GCS_SA
+                  value: service-account.json
+              args:
+                - /bin/bash
+                - -c
+                - mysqldump --user="${DB_USER}" --password="${DB_PASS}" --host="${DB_HOST}" "$@" "${DB_NAME}" > "${DB_NAME}-$(date '+%d|%m|%Y-%H:%M:%S')".sql; gcloud config set project ${GOOGLE_PROJECT}; gcloud auth activate-service-account --key-file "${GCS_SA}"; gsutil cp *.sql gs://"${GCS_BUCKET}"

--- a/jobs/mysql-secret.yaml
+++ b/jobs/mysql-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+type: Opaque
+data:
+  password: <passencrypted-output>


### PR DESCRIPTION
# Problem
CronJob example is needed for Academy

# Solution
CronJob example in GKE needs to be configured. See jobs folder to explore files needed for this task

# Testing
This example was tested in a gmail account, it works, backup is created and stored in a bucket